### PR TITLE
fix the repetition loop list append

### DIFF
--- a/deepspeed/runtime/engine.py
+++ b/deepspeed/runtime/engine.py
@@ -127,8 +127,13 @@ def split_half_float_double_sparse(tensors):
 
     sparse_tensor_buckets, dense_tensor_buckets = [], []
     for i, dtype in enumerate(supported_types):
-        sparse_bucket = [t for t in tensors if isinstance(t, SparseTensor)]
-        dense_bucket = [t for t in tensors if not isinstance(t, SparseTensor)]
+        sparse_bucket, dense_bucket = [], []
+        for t in tensors:
+            if t.dtype == dtype:
+                if isinstance(t, SparseTensor):
+                    sparse_bucket.append(t)
+                else:
+                    dense_bucket.append(t)
         if sparse_bucket:
             sparse_tensor_buckets.append((dtype, sparse_bucket))
         if dense_bucket:


### PR DESCRIPTION
In the case of multiple supported dtypes, the loop causes repetitive additions to the bucket. Consequently, this leads to multiple 'allreduce' operations, resulting in the 'allclose' issue.